### PR TITLE
Remove quotes around $kubectl_command to fix invalid command error.

### DIFF
--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -113,7 +113,7 @@ getJSON() {
             die "Could not access API"
         fi
     else
-        data=$(timeout "$TIMEOUT" kubectl "$kubectl_command" -o json 2>&1)
+        data=$(timeout "$TIMEOUT" kubectl $kubectl_command -o json 2>&1)
         code=$?
         if [ $code -gt 0 ]; then
             if [ $code = 124 ]; then


### PR DESCRIPTION
Hi,

It seems the quotes around `$kubectl_command` cause `kubectl` to interpret the whole string as a single command. Leading to the following error.

```
$ bash -x /opt/monitoring/plugins/check_kubernetes.sh -K /var/lib/nagios/kube_config -m pods
+ BRIEF=0
+ TIMEOUT=15
+ getopts :m:H:T:t:K:N:n:o:c:w:bh arg
+ case $arg in
+ export KUBECONFIG=/var/lib/nagios/kube_config
+ KUBECONFIG=/var/lib/nagios/kube_config
+ getopts :m:H:T:t:K:N:n:o:c:w:bh arg
+ case $arg in
+ MODE=pods
+ getopts :m:H:T:t:K:N:n:o:c:w:bh arg
+ '[' -z pods ']'
+ '[' '' ']'
+ command -v kubectl
+ command -v jq
+ OUTPUT=
+ EXITCODE=0
+ kubectl_ns=--all-namespaces
+ '[' '' ']'
+ case "$MODE" in
+ mode_pods
+ WARN=30
+ CRIT=150
+ '[' 30 -gt 150 ']'
+ count_ready=0
+ count_succeeded=0
+ count_failed=0
+ max_restart_count=0
+ bad_container=
++ getJSON 'get pods --all-namespaces' api/v1/pods/
++ kubectl_command='get pods --all-namespaces'
++ api_path=api/v1/pods/
++ '[' '' ']'
+++ timeout 15 kubectl 'get pods --all-namespaces' -o json
++ data='Error: unknown command "get pods --all-namespaces" for "kubectl"
Run '\''kubectl --help'\'' for usage.
unknown command "get pods --all-namespaces" for "kubectl"'
++ code=1
++ '[' 1 -gt 0 ']'
++ '[' 1 = 124 ']'
++ die 'Error: unknown command "get pods --all-namespaces" for "kubectl"
Run '\''kubectl --help'\'' for usage.
unknown command "get pods --all-namespaces" for "kubectl"'
++ '[' 0 = 1 ']'
++ echo 'Error: unknown command "get pods --all-namespaces" for "kubectl"
Run '\''kubectl --help'\'' for usage.
unknown command "get pods --all-namespaces" for "kubectl"'
++ exit 2
+ data='Error: unknown command "get pods --all-namespaces" for "kubectl"
Run '\''kubectl --help'\'' for usage.
unknown command "get pods --all-namespaces" for "kubectl"'
+ '[' 2 -gt 0 ']'
+ die 'Error: unknown command "get pods --all-namespaces" for "kubectl"
Run '\''kubectl --help'\'' for usage.
unknown command "get pods --all-namespaces" for "kubectl"'
+ '[' 0 = 1 ']'
+ echo 'Error: unknown command "get pods --all-namespaces" for "kubectl"
Run '\''kubectl --help'\'' for usage.
unknown command "get pods --all-namespaces" for "kubectl"'
Error: unknown command "get pods --all-namespaces" for "kubectl"
Run 'kubectl --help' for usage.
unknown command "get pods --all-namespaces" for "kubectl"
+ exit 2
```

Removing the quotes and adding all command parts separately seems to fix the issue. I haven't seen any side-effects yet.