### PR TITLE
Have jq skip over pods without containerStatuses

### DIFF
--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -367,7 +367,7 @@ mode_pods() {
         for pod in "${pods[@]}"; do
             containers=($(echo "$nsdata" | \
                           jq -r "select(.metadata.name==\"$pod\") | \
-                                 .status.containerStatuses[].name"))
+                                 .status.containerStatuses[]?.name"))
             for container in "${containers[@]}"; do
                 restart_count=$(echo "$nsdata" | \
                                 jq -r "select(.metadata.name==\"$pod\") | \


### PR DESCRIPTION
A pending pod will not have any containerStatuses as the container has yet to be deployed and this line of code errors with `jq: error (at <stdin>:5): Cannot iterate over null (null)` on any pod with a pending status (in my case because I purposefully made the pod schedulable) on my nodes.  Adding the ? will have jq skip over instances that do not have results.