### PR TITLE
Improve CheckCommand for Icinga2

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,17 +142,21 @@ Command:
       command = [ PluginDir + "/check_kubernetes.sh" ]
     
       arguments = {
-                    "-H" = "$kube_scheme$://$host.address$:$kube_port$"
-                    "-m" = "$kube_mode$"
-                    "-o" = "$kube_timeout$"
-                    "-T" = "$kube_pass$"
-                    "-t" = "$kube_tokenfile$"
-                    "-K" = "$kube_config$"
-                    "-N" = "$kube_ns$"
-                    "-n" = "$kube_name$"
-                    "-w" = "$kube_warn$"
-                    "-c" = "$kube_crit$"
+        "-H" = "$kube_apiserver$"
+        "-m" = "$kube_mode$"
+        "-o" = "$kube_timeout$"
+        "-T" = "$kube_pass$"
+        "-t" = "$kube_tokenfile$"
+        "-K" = "$kube_config$"
+        "-N" = "$kube_ns$"
+        "-n" = "$kube_name$"
+        "-w" = "$kube_warn$"
+        "-c" = "$kube_crit$"
       }
+      vars.kube_host = "$host.address$"
+      vars.kube_port = 6443
+      vars.kube_scheme = "https"
+      vars.kube_apiserver = "$kube_scheme$://$kube_host$:$kube_port$"
     }
     
 Services:


### PR DESCRIPTION
This change introduces some default values for kube_port and kube_scheme and a new variable kube_apiserver. The kube_apiserver is used as in the example before but now it is possible to override the apiserver without splitting it into port, host and scheme.

Please feel free to contact me if you have any questions.