### PR TITLE
modfiy the if-condition order to check the CRIT state at first. Other…

### DIFF
--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -391,12 +391,13 @@ mode_pods() {
             else
                 ((count_failed++))
             fi
+            if [ "$restart_count" -ge "$CRIT" ]; then
+              OUTPUT="${OUTPUT}Container $bad_container in CRIT: $restart_count restarts.\n"
+              EXITCODE=2
+            fi
             if [ "$restart_count" -ge "$WARN" ]; then
-                OUTPUT="${OUTPUT}Container $bad_container: $restart_count restarts.\n"
+                OUTPUT="${OUTPUT}Container $bad_container in WARN: $restart_count restarts.\n"
                 EXITCODE=1
-                if [ "$restart_count" -ge "$CRIT" ]; then
-                    EXITCODE=2
-                fi
             fi
         done
     done


### PR DESCRIPTION
modfiy the if-condition order to check the CRIT state at first. Otherwise we check the WARN at first and bypass the CRIT check because the WARN state will also be true if the $restart_count is actually in CRIT.