### PR TITLE
add MODE: apicert to check the expiration date

### DIFF
--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -28,13 +28,13 @@ usage() {
 	                    - Pod restart count in pods mode; default is 30
 	                    - Job failed count in jobs mode; default is 1
 	                    - Pvc storage utilization; default is 80%
-                      - APICERT expiration days for apicert mode; default is 30
+                            - APICERT expiration days for apicert mode; default is 30
 	  -c CRIT          Critical threshold for
 	                    - Pod restart count (in pods mode); default is 150
 	                    - Unbound Persistent Volumes in unboundpvs mode; default is 5
 	                    - Job failed count in jobs mode; default is 2
 	                    - Pvc storage utilization; default is 90%
-                      - APICERT expiration days for apicert mode; default is 15
+                            - APICERT expiration days for apicert mode; default is 15
 	  -M EXIT_CODE     Exit code when resource is missing; default is 2 (CRITICAL)
 	  -h               Show this help and exit
 

--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -164,10 +164,10 @@ mode_apicert() {
     echo "APICERT expires in $d days"
     if [ "$d" -gt "$WARN" ]; then
         echo "APICERT is OK"
-    elif [ $d -le $WARN ] && [ $d -gt $CRIT ]; then
+    elif [ "$d" -le "$WARN" ] && [ $d -gt "$CRIT" ]; then
         echo "APICERT is in WARN"
         EXITCODE=1
-    elif [ $d -le $CRIT ]; then
+    elif [ "$d" -le "$CRIT" ]; then
         echo "APICERT is in CRIT"
         EXITCODE=2
     fi

--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -176,6 +176,9 @@ mode_apicert() {
     elif [ "$d" -le "$CRIT" ]; then
         echo "APICERT is in CRIT"
         EXITCODE=2
+    else
+        echo "APICERT is in UNKNOWN"
+        EXITCODE=3
     fi
 }
 

--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -162,6 +162,11 @@ mode_apicert() {
     APICERT=$(echo "$APISERVER" | awk -F "//" '{ print $2 }' | awk -F ":" '{ print $1 }')
     APIPORT=$(echo "$APISERVER" | awk -F "//" '{ print $2 }' | awk -F ":" '{ print $2 }')
     APIPORT=${APIPORT:=443}
+    timeout "$TIMEOUT" bash -c "</dev/tcp/$APICERT/$APIPORT" &>/dev/null
+    if [ $? -ne 0 ]; then
+        echo "APICERT is in UNKNOWN"
+        exit 3
+    fi
     APICERTDATE=$(echo | openssl s_client -connect "$APICERT":"$APIPORT" 2>/dev/null | openssl x509 -noout -dates | grep notAfter | sed -e 's#notAfter=##')
     a=$(date -d "$APICERTDATE" +%s)
     b=$(date +%s)
@@ -176,9 +181,6 @@ mode_apicert() {
     elif [ "$d" -le "$CRIT" ]; then
         echo "APICERT is in CRIT"
         EXITCODE=2
-    else
-        echo "APICERT is in UNKNOWN"
-        EXITCODE=3
     fi
 }
 

--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -156,7 +156,9 @@ mode_apicert() {
         die "Apiserver URL should be defined in this mode"
     fi
     APICERT=$(echo "$APISERVER" | awk -F "//" '{ print $2 }' | awk -F ":" '{ print $1 }')
-    APICERTDATE=$(echo | openssl s_client -connect "$APICERT":6443 2>/dev/null | openssl x509 -noout -dates | grep notAfter | sed -e 's#notAfter=##')
+    APIPORT=$(echo "$APISERVER" | awk -F "//" '{ print $2 }' | awk -F ":" '{ print $2 }')
+    set ${APIPORT:=443}
+    APICERTDATE=$(echo | openssl s_client -connect "$APICERT":"$APIPORT" 2>/dev/null | openssl x509 -noout -dates | grep notAfter | sed -e 's#notAfter=##')
     a=$(date -d "$APICERTDATE" +%s)
     b=$(date +%s)
     c=$((a-b))


### PR DESCRIPTION
The K8s API use also the internal PKI TLS certificate to provide HTTPs. We can check the TLS certificate on port 6443 to check the expiredate of the internal PKI TLS certificate. We can use params like -w 30 (days) and -c 15 (days) to sent warning and critical alarms. This would be a own MODE.

The API cert in K8s: /etc/kubernetes/pki/apiserver.crt


example:

if APIPORT is on 443 (you don't have to specify the port)
./check_kubernetes.sh -H https://192.168.100.10 -t $TOKENFILE -m apicert -w 30 -c 15

if APIPORT != 443 (you have to specify the port)
./check_kubernetes.sh -H https://192.168.100.10:6443 -t $TOKENFILE -m apicert -w 30 -c 15


