### PR TITLE
Add critical threshold for TLS expiration days in TLS mode

### DIFF
--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2181,SC2207,SC2199,SC2076
+#
 
 ##########################
 # Perform checks against Kubernetes API or with tab help of kubectl utility

--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -30,7 +30,7 @@ usage() {
 	                    - Pvc storage utilization; default is 80%
 	                    - API cert expiration days for apicert mode; default is 30
 	  -c CRIT          Critical threshold for
-	                    - TLS expiration days for TLS mode; default is 5
+	                    - TLS expiration days for TLS mode; default is 0
 	                    - Pod restart count (in pods mode); default is 150
 	                    - Unbound Persistent Volumes in unboundpvs mode; default is 5
 	                    - Job failed count in jobs mode; default is 2
@@ -298,7 +298,7 @@ mode_pvc() {
 
 mode_tls() {
     WARN=${WARN:-30}
-    CRIT=${CRIT:-5}
+    CRIT=${CRIT:-0}
 
     count_ok=0
     count_warn=0

--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # shellcheck disable=SC2181,SC2207,SC2199,SC2076
-#
 
 ##########################
 # Perform checks against Kubernetes API or with tab help of kubectl utility
@@ -31,6 +30,7 @@ usage() {
 	                    - Pvc storage utilization; default is 80%
 	                    - API cert expiration days for apicert mode; default is 30
 	  -c CRIT          Critical threshold for
+	                    - TLS expiration days for TLS mode; default is 5
 	                    - Pod restart count (in pods mode); default is 150
 	                    - Unbound Persistent Volumes in unboundpvs mode; default is 5
 	                    - Job failed count in jobs mode; default is 2
@@ -298,6 +298,7 @@ mode_pvc() {
 
 mode_tls() {
     WARN=${WARN:-30}
+    CRIT=${CRIT:-5}
 
     count_ok=0
     count_warn=0
@@ -338,6 +339,10 @@ mode_tls() {
                 ((count_crit++))
                 EXITCODE=2
                 OUTPUT="$OUTPUT $ns/$cert is expired."
+            elif [ "$diff" -le "$((CRIT*24*3600))" ]; then
+                ((count_crit++))
+                EXITCODE=2
+                OUTPUT="$OUTPUT $ns/$cert is about to expire in $((diff/3600/24)) days."
             elif [ "$diff" -le "$((WARN*24*3600))" ]; then
                 ((count_warn++))
                 if [ "$EXITCODE" == 0 ]; then


### PR DESCRIPTION
Hi, 
I had a situation where I needed an alert to be sent if the renew date for tls certificates is below 30 days, and a different alert (with different contactgroups) to be sent on 5 days left. So I added the option for a critical threshold too to mode_tls.
