### PR TITLE
Check the maxPods Value on each clustermembers

### DIFF
--- a/check_kubernetes.sh
+++ b/check_kubernetes.sh
@@ -26,12 +26,14 @@ usage() {
 	  -w WARN          Warning threshold for
 	                    - TLS expiration days for TLS mode; default is 30
 	                    - Pod restart count in pods mode; default is 30
+	                    - MaxPods Pod count on each system; default is 90%
 	                    - Job failed count in jobs mode; default is 1
 	                    - Pvc storage utilization; default is 80%
 	                    - API cert expiration days for apicert mode; default is 30
 	  -c CRIT          Critical threshold for
 	                    - TLS expiration days for TLS mode; default is 0
 	                    - Pod restart count (in pods mode); default is 150
+	                    - MaxPods Pod count on each system; default is 95%
 	                    - Unbound Persistent Volumes in unboundpvs mode; default is 5
 	                    - Job failed count in jobs mode; default is 2
 	                    - Pvc storage utilization; default is 90%
@@ -48,6 +50,7 @@ usage() {
 	  deployments      Check for deployments availability
 	  jobs             Check for failed jobs
 	  pods             Check for restart count of containters in the pods
+	  maxpods          Check the maxPods value and detect high pod count on each system
 	  replicasets      Check for replicasets readiness
 	  statefulsets     Check for statefulsets readiness
 	  tls              Check for tls secrets expiration dates
@@ -58,7 +61,7 @@ usage() {
     exit 2
 }
 
-VERSION="v1.3.2"
+VERSION="v1.4.0"
 
 TIMEOUT=15
 unset NAME
@@ -367,6 +370,42 @@ mode_tls() {
             fi
         fi
     fi
+}
+
+mode_maxpods() {
+    WARN=${WARN:-90}
+    CRIT=${CRIT:-95}
+
+    data="$(getJSON "api/v1/nodes")"
+    [ $? -gt 0 ] && die "$data"
+    k8smembers=$(echo "$data" | jq -r ".items[] | .metadata.name" | tr -d '"')
+
+    for m in $k8smembers
+    do
+      maxpods=$(getJSON "api/v1/nodes/$m" | jq ".status.capacity.pods" | tr -d '"')
+      currentpods=$(getJSON "api/v1/pods" | jq '[.items[] | select(.spec.nodeName=="'"$m"'")] | length')
+      maxpods_percent=$((currentpods * 100 / maxpods))
+
+      if [ "$maxpods_percent" -ge "$WARN" ]
+      then
+        EXITCODE=1
+        if [ "$maxpods_percent" -ge "$CRIT" ]
+        then
+          EXITCODE=2
+        fi
+      fi
+
+      if [ $EXITCODE = 0 ]
+      then
+        echo -e "Pod count are OK\n"
+      elif [ $EXITCODE = 1 ]
+      then
+        echo -e "WARNING. Pod count is $maxpods_percent% on $m\n"
+      elif [ $EXITCODE = 2 ]
+      then
+        echo -e "CRITICAL. Pod count is $maxpods_percent% on $m\n"
+      fi
+    done
 }
 
 mode_pods() {
@@ -772,6 +811,7 @@ case "$MODE" in
     (nodes) mode_nodes ;;
     (unboundpvs) mode_unboundpvs ;;
     (pods) mode_pods ;;
+    (maxpods) mode_maxpods ;;
     (replicasets) mode_replicasets ;;
     (statefulsets) mode_statefulsets ;;
     (tls) mode_tls ;;


### PR DESCRIPTION
A new check to detect the maxPods value on each clustermembers in Kubernetes and check the Pod count on each system.
The default limit in Kubernetes is 110 Pods on each member.
You can't run more Pods on the system without configuring the cluster. The new -m maxpods check is able to check the pod count and inform you about resource bottlenecks.